### PR TITLE
Replace side toggle with quality controls

### DIFF
--- a/app.py
+++ b/app.py
@@ -68,6 +68,7 @@ def search_page():
             "context": request.args.get("context"),
             "situation": request.args.get("situation"),
             "quality": request.args.get("quality"),
+            "distance": request.args.get("distance"),
             "traits": [t for t in request.args.get("traits", "").split(",") if t],
             "roles": [r for r in request.args.get("roles", "").split(",") if r],
             "subroles": [s for s in request.args.get("subroles", "").split(",") if s],

--- a/app.py
+++ b/app.py
@@ -46,10 +46,10 @@ def players():
     return jsonify({"players": get_player_names()})
 
 
-@app.route("/clip/<player>/<side>/<path:filename>")
-def serve_clip(player, side, filename):
-    """Return the video file for the given player/side/filename."""
-    path = Path(config.BASE_DIR) / player / side / filename
+@app.route("/clip/<player>/<path:filename>")
+def serve_clip(player, filename):
+    """Return the video file for the given player/filename."""
+    path = Path(config.BASE_DIR) / player / filename
     if not path.exists():
         abort(404)
     return send_file(path)
@@ -63,11 +63,10 @@ def search_page():
         # Split comma-separated strings into arrays and filter out empty strings
         filters = {
             "player": request.args.get("player"),
-            "side": request.args.get("side"),
-            "playtype": request.args.get("playtype"),  # value format from taggerData.js is already correct
+            "playtype": request.args.get("playtype"),
             "outcome": request.args.get("outcome"),
             "context": request.args.get("context"),
-            "situation": request.args.get("situation"),  # value format from taggerData.js is already correct
+            "situation": request.args.get("situation"),
             "quality": request.args.get("quality"),
             "traits": [t for t in request.args.get("traits", "").split(",") if t],
             "roles": [r for r in request.args.get("roles", "").split(",") if r],
@@ -77,14 +76,15 @@ def search_page():
         logs = load_logs()
         for entry in logs:
             if matches(entry, filters):
-                path = Path(config.BASE_DIR) / entry["player"] / entry["side"] / entry["filename"]
-                results.append({
-                    "label": f"{entry['player']}: {entry['filename']}",
-                    "full_path": str(path),
-                    "player": entry["player"],
-                    "side": entry["side"],
-                    "filename": entry["filename"],
-                })
+                path = Path(config.BASE_DIR) / entry["player"] / entry["filename"]
+                results.append(
+                    {
+                        "label": f"{entry['player']}: {entry['filename']}",
+                        "full_path": str(path),
+                        "player": entry["player"],
+                        "filename": entry["filename"],
+                    }
+                )
     return render_template("search.html", players=players, results=results, args=request.args)
 
 

--- a/search_clips.py
+++ b/search_clips.py
@@ -46,6 +46,7 @@ def main(argv=None):
     parser.add_argument("--context")
     parser.add_argument("--situation")
     parser.add_argument("--quality")
+    parser.add_argument("--distance")
     parser.add_argument("--trait", action="append", dest="traits")
     parser.add_argument("--role", action="append", dest="roles")
     parser.add_argument("--subrole", action="append", dest="subroles")
@@ -60,6 +61,7 @@ def main(argv=None):
         "context": args.context,
         "situation": args.situation,
         "quality": args.quality,
+        "distance": args.distance,
         "traits": args.traits,
         "roles": args.roles,
         "subroles": args.subroles,

--- a/search_clips.py
+++ b/search_clips.py
@@ -41,7 +41,6 @@ def matches(entry, filters):
 def main(argv=None):
     parser = argparse.ArgumentParser(description="Search tagged clips")
     parser.add_argument("--player")
-    parser.add_argument("--side")
     parser.add_argument("--playtype")
     parser.add_argument("--outcome")
     parser.add_argument("--context")
@@ -56,7 +55,6 @@ def main(argv=None):
 
     filters = {
         "player": args.player,
-        "side": args.side,
         "playtype": args.playtype,
         "outcome": args.outcome,
         "context": args.context,
@@ -71,7 +69,7 @@ def main(argv=None):
     logs = load_logs()
     results = [e for e in logs if matches(e, filters)]
     for e in results:
-        path = Path(config.BASE_DIR) / e["player"] / e["side"] / e["filename"]
+        path = Path(config.BASE_DIR) / e["player"] / e["filename"]
         print(path)
 
 

--- a/static/search.js
+++ b/static/search.js
@@ -39,14 +39,11 @@ function populateSearch() {
     if (hidden) hidden.value = qualityVal;
   }
 
-  // Roles handling - split comma separated roles and update both selects
+  // Role handling - set select and hidden input
   const rolesVal = params.get("roles");
   if (rolesVal) {
-    const [off, def] = rolesVal.split(",");
-    const offenseSelect = document.querySelector("select[name='offense_role']");
-    const defenseSelect = document.querySelector("select[name='defense_role']");
-    if (offenseSelect) offenseSelect.value = off || "";
-    if (defenseSelect) defenseSelect.value = def || "";
+    const roleSelect = document.querySelector("select[name='role']");
+    if (roleSelect) roleSelect.value = rolesVal;
     if (typeof updateRoles === "function") updateRoles();
   }
 

--- a/static/search.js
+++ b/static/search.js
@@ -39,11 +39,22 @@ function populateSearch() {
     if (hidden) hidden.value = qualityVal;
   }
 
+  const distanceVal = params.get("distance");
+  if (distanceVal) {
+    document
+      .querySelectorAll(".distance-group .toggle-button")
+      .forEach((btn) => {
+        btn.classList.toggle("selected", btn.dataset.value === distanceVal);
+      });
+    const hidden = document.querySelector('input[name="distance"]');
+    if (hidden) hidden.value = distanceVal;
+  }
+
   // Role handling - set select and hidden input
   const rolesVal = params.get("roles");
   if (rolesVal) {
-    const offenseSelect = document.querySelector("select[name='offense_role']");
-    if (offenseSelect) offenseSelect.value = rolesVal;
+    const roleSelect = document.querySelector("select[name='role']");
+    if (roleSelect) roleSelect.value = rolesVal;
     if (typeof updateRoles === "function") updateRoles();
   }
 

--- a/static/style.css
+++ b/static/style.css
@@ -230,13 +230,6 @@ button[type="submit"]:hover {
   flex: 1 1 50%;
 }
 
-/* Force offense/defense blocks side by side */
-.role-container {
-  display: flex;
-  justify-content: space-between;
-  gap: 12px;
-  flex-wrap: wrap;
-}
 
 /* Stack options vertically */
 .vertical-options {

--- a/static/style.css
+++ b/static/style.css
@@ -132,6 +132,16 @@ button[type="submit"]:hover {
   min-width: 4rem;
 }
 
+/* Center and size the distance toggle */
+.distance-group {
+  justify-content: center;
+  margin: 0 auto;
+}
+.distance-group .toggle-button {
+  flex: 0 0 auto;
+  min-width: 4rem;
+}
+
 .toggle-button {
   flex: 1;
   text-align: center;
@@ -229,7 +239,6 @@ button[type="submit"]:hover {
 .form-section-flex > div {
   flex: 1 1 50%;
 }
-
 
 /* Stack options vertically */
 .vertical-options {

--- a/static/taggerData.js
+++ b/static/taggerData.js
@@ -1,4 +1,4 @@
-const offensiveRoles = [
+const roles = [
   "Pocket Passer",
   "Dual-Threat QB",
   "Mobile QB",
@@ -11,21 +11,7 @@ const offensiveRoles = [
   "Red Zone Specialist",
 ];
 
-const defensiveRoles = [
-  "Point-of-Attack Defender",
-  "Chaser",
-  "Wing Stopper",
-  "Off-Ball Helper",
-  "Defensive Playmaker",
-  "Defensive Quarterback",
-  "Switchable Wing",
-  "Switchable Big",
-  "Mobile Big",
-  "Post Defender",
-  "Anchor Big",
-];
-
-const offensiveSubrolesPositive = [
+const subrolesPositive = [
   "Accurate Passer",
   "Deep Ball Thrower",
   "Quick Release",
@@ -42,7 +28,7 @@ const offensiveSubrolesPositive = [
   "Big Play Maker",
 ];
 
-const offensiveSubrolesNegative = [
+const subrolesNegative = [
   "Inaccurate Passes",
   "Poor Decision Making",
   "Slow Release",
@@ -60,41 +46,6 @@ const offensiveSubrolesNegative = [
   "Stares Down Receivers",
 ];
 
-const defensiveSubrolesPositive = [
-  "Pass Rush",
-  "Coverage Skills",
-  "Run Defense",
-  "Blitz Execution",
-  "Containment",
-  "QB Spy",
-  "Zone Coverage",
-  "Man Coverage",
-  "Pressure Creation",
-  "Gap Control",
-  "Pursuit",
-  "Tackling",
-  "Disruption",
-  "Communication",
-  "Recognition",
-];
-
-const defensiveSubrolesNegative = [
-  "Poor Pass Rush",
-  "Coverage Lapses",
-  "Run Defense Issues",
-  "Missed Tackles",
-  "Poor Angles",
-  "Late Recognition",
-  "Blown Assignments",
-  "Poor Pursuit",
-  "Gap Issues",
-  "Penalty Prone",
-  "Poor Communication",
-  "Overaggressive",
-  "Out of Position",
-  "Slow Reactions",
-  "Missed Containment",
-];
 
 const traits = [
   "Arm Strength",
@@ -275,60 +226,38 @@ function populateTags() {
     contextSelect.add(option);
   });
 
-  // Roles (Offense & Defense)
-  const roleSelects = document.querySelectorAll(
+  // Role selection
+  const roleSelect = document.querySelector(
     "#roles-section select.role-select"
   );
-  if (roleSelects.length >= 2) {
-    const [offenseSelect, defenseSelect] = roleSelects;
-    const offensePlaceholder = new Option("Offense", "");
-    offensePlaceholder.className = "placeholder-option";
-    offenseSelect.add(offensePlaceholder);
-    const defensePlaceholder = new Option("Defense", "");
-    defensePlaceholder.className = "placeholder-option";
-    defenseSelect.add(defensePlaceholder);
-    offensiveRoles.forEach((role) => {
-      offenseSelect.add(new Option(role, role));
-    });
-    defensiveRoles.forEach((role) => {
-      defenseSelect.add(new Option(role, role));
+  if (roleSelect) {
+    const placeholder = new Option("Role", "");
+    placeholder.className = "placeholder-option";
+    roleSelect.add(placeholder);
+    roles.forEach((role) => {
+      roleSelect.add(new Option(role, role));
     });
 
     const hiddenInput = document.querySelector("input[name='roles']");
     window.updateRoles = () => {
-      const selected = [offenseSelect.value, defenseSelect.value].filter(
-        Boolean
-      );
-      hiddenInput.value = selected.join(",");
+      hiddenInput.value = roleSelect.value || "";
     };
 
-    offenseSelect.addEventListener("change", window.updateRoles);
-    defenseSelect.addEventListener("change", window.updateRoles);
+    roleSelect.addEventListener("change", window.updateRoles);
     // Initialize hidden value
     window.updateRoles();
   }
 
-  // SubRoles (Offense & Defense, with Positive/Negative sections)
-  const subroleLists = document.querySelectorAll("#subroles-section .tag-list");
-  if (subroleLists.length >= 2) {
-    const [offenseList, defenseList] = subroleLists;
-
-    offenseList.innerHTML += "<div class='subrole-divider'>Positive</div>";
-    offensiveSubrolesPositive.forEach((sub) =>
-      offenseList.appendChild(createSelectable(sub, "subroles"))
+  // SubRoles with Positive/Negative sections
+  const subroleList = document.querySelector("#subroles-section .tag-list");
+  if (subroleList) {
+    subroleList.innerHTML += "<div class='subrole-divider'>Positive</div>";
+    subrolesPositive.forEach((sub) =>
+      subroleList.appendChild(createSelectable(sub, "subroles"))
     );
-    offenseList.innerHTML += "<div class='subrole-divider'>Negative</div>";
-    offensiveSubrolesNegative.forEach((sub) =>
-      offenseList.appendChild(createSelectable(sub, "subroles"))
-    );
-
-    defenseList.innerHTML += "<div class='subrole-divider'>Positive</div>";
-    defensiveSubrolesPositive.forEach((sub) =>
-      defenseList.appendChild(createSelectable(sub, "subroles"))
-    );
-    defenseList.innerHTML += "<div class='subrole-divider'>Negative</div>";
-    defensiveSubrolesNegative.forEach((sub) =>
-      defenseList.appendChild(createSelectable(sub, "subroles"))
+    subroleList.innerHTML += "<div class='subrole-divider'>Negative</div>";
+    subrolesNegative.forEach((sub) =>
+      subroleList.appendChild(createSelectable(sub, "subroles"))
     );
   }
 }

--- a/static/taggerData.js
+++ b/static/taggerData.js
@@ -233,7 +233,7 @@ function populateTags() {
     const placeholder = new Option("Role", "");
     placeholder.className = "placeholder-option";
     roleSelect.add(placeholder);
-    offensiveRoles.forEach((role) => {
+    roles.forEach((role) => {
       roleSelect.add(new Option(role, role));
     });
 
@@ -255,7 +255,7 @@ function populateTags() {
       subroleList.appendChild(createSelectable(sub, "subroles"))
     );
     subroleList.innerHTML += "<div class='subrole-divider'>Negative</div>";
-    offensiveSubrolesNegative.forEach((sub) =>
+    subrolesNegative.forEach((sub) =>
       subroleList.appendChild(createSelectable(sub, "subroles"))
     );
   }

--- a/tag_utils.py
+++ b/tag_utils.py
@@ -31,6 +31,7 @@ def process_clip_tags(clip_path, data):
     context = data.get("context", [""])[0]
     situation = data.get("situation", [""])[0]
     quality = data.get("quality", ["Good"])[0]
+    distance = data.get("distance", [""])[0]
 
     # Rename file with incrementing numeric suffix if needed
     ext = Path(clip_path).suffix
@@ -73,6 +74,7 @@ def process_clip_tags(clip_path, data):
             "context": context,
             "situation": situation,
             "quality": quality,
+            "distance": distance,
         }
     )
 

--- a/tag_utils.py
+++ b/tag_utils.py
@@ -14,7 +14,6 @@ BASE_DIR = config.BASE_DIR
 
 def process_clip_tags(clip_path, data):
     player = data.get("player", [""])[0]
-    side = data.get("side", ["Offense"])[0]
     playtype = data.get("playtype", [""])[0]
     outcome = data.get("outcome", [""])[0]
 
@@ -36,7 +35,7 @@ def process_clip_tags(clip_path, data):
     # Rename file with incrementing numeric suffix if needed
     ext = Path(clip_path).suffix
     base_name = f"{playtype}_{situation}_{outcome}"
-    new_dir = BASE_DIR / player / side
+    new_dir = BASE_DIR / player
     try:
         new_dir.mkdir(parents=True, exist_ok=True)
         count = 0
@@ -62,19 +61,20 @@ def process_clip_tags(clip_path, data):
             logging.error("Failed to load log %s: %s", log_path, exc)
             log = []
 
-    log.append({
-        "filename": new_name,
-        "side": side,
-        "playtype": playtype,
-        "outcome": outcome,
-        "traits": traits,
-        "roles": roles,
-        "subroles": subroles,
-        "badges": badges,
-        "context": context,
-        "situation": situation,
-        "quality": quality,
-    })
+    log.append(
+        {
+            "filename": new_name,
+            "playtype": playtype,
+            "outcome": outcome,
+            "traits": traits,
+            "roles": roles,
+            "subroles": subroles,
+            "badges": badges,
+            "context": context,
+            "situation": situation,
+            "quality": quality,
+        }
+    )
 
     try:
         with open(log_path, "w") as f:

--- a/templates/search.html
+++ b/templates/search.html
@@ -21,19 +21,6 @@
         // This will be done after populateTags() runs in taggerData.js
 
         document
-          .querySelectorAll(".side-group .toggle-button")
-          .forEach((btn) => {
-            btn.addEventListener("click", () => {
-              document
-                .querySelectorAll(".side-group .toggle-button")
-                .forEach((b) => b.classList.remove("selected"));
-              btn.classList.add("selected");
-              document.querySelector('input[name="side"]').value =
-                btn.dataset.value;
-            });
-          });
-
-        document
           .querySelectorAll(".quality-group .toggle-button")
           .forEach((btn) => {
             btn.addEventListener("click", () => {
@@ -97,39 +84,6 @@
             <option value="{{ p }}"></option>
             {% endfor %}
           </datalist>
-          <div class="toggle-group">
-            <div
-              class="toggle-button {% if args.get('side','Offense')=='Offense' %}selected{% endif %}"
-              data-value="Offense"
-            >
-              Offense
-            </div>
-            <div
-              class="toggle-button {% if args.get('side')=='Defense' %}selected{% endif %}"
-              data-value="Defense"
-            >
-              Defense
-            </div>
-          </div>
-          <input
-            type="hidden"
-            name="side"
-            value="{{ args.get('side','Offense') }}"
-          />
-        </div>
-
-        <hr class="section-divider" />
-
-        <div class="form-row">
-          <select name="playtype"></select>
-          <select name="situation"></select>
-        </div>
-        <div class="form-row">
-          <select name="outcome"></select>
-          <select name="context"></select>
-        </div>
-
-        <div class="form-row">
           <div class="toggle-group quality-group">
             <div
               class="toggle-button {% if args.get('quality')=='Good' %}selected{% endif %}"
@@ -153,6 +107,17 @@
 
         <hr class="section-divider" />
 
+        <div class="form-row">
+          <select name="playtype"></select>
+          <select name="situation"></select>
+        </div>
+        <div class="form-row">
+          <select name="outcome"></select>
+          <select name="context"></select>
+        </div>
+
+        <hr class="section-divider" />
+
         <div class="form-group">
           <label>Traits</label>
           <div class="chip-row" data-field="traits"></div>
@@ -164,14 +129,9 @@
         </div>
 
         <div id="roles-section" class="tag-section">
-          <label>Roles</label>
-          <div class="dual-column">
-            <div class="column-block">
-              <select class="role-select" name="offense_role"></select>
-            </div>
-            <div class="column-block">
-              <select class="role-select" name="defense_role"></select>
-            </div>
+          <label>Role</label>
+          <div class="column-block">
+            <select class="role-select" name="role"></select>
           </div>
           <input
             type="hidden"
@@ -183,33 +143,16 @@
         <details class="subrole-drawer">
           <summary>SubRoles</summary>
           <div id="subroles-section" class="tag-section">
-            <div class="dual-column compact-mode">
-              <div class="column-block">
-                <div class="tag-box">
-                  <div class="box-header-row">
-                    <span class="box-title">Offense</span>
-                    <input
-                      type="text"
-                      class="filter-input"
-                      placeholder="Search..."
-                    />
-                  </div>
-                  <div class="tag-list scrollable" data-filter-group></div>
-                </div>
+            <div class="tag-box">
+              <div class="box-header-row">
+                <span class="box-title">SubRoles</span>
+                <input
+                  type="text"
+                  class="filter-input"
+                  placeholder="Search..."
+                />
               </div>
-              <div class="column-block">
-                <div class="tag-box">
-                  <div class="box-header-row">
-                    <span class="box-title">Defense</span>
-                    <input
-                      type="text"
-                      class="filter-input"
-                      placeholder="Search..."
-                    />
-                  </div>
-                  <div class="tag-list scrollable" data-filter-group></div>
-                </div>
-              </div>
+              <div class="tag-list scrollable" data-filter-group></div>
             </div>
             <input
               type="hidden"
@@ -243,7 +186,7 @@
         {% for r in results %}
         <li data-path="{{ r.full_path }}">
           <a
-            href="{{ url_for('serve_clip', player=r.player, side=r.side, filename=r.filename) }}"
+            href="{{ url_for('serve_clip', player=r.player, filename=r.filename) }}"
             target="_blank"
           >
             {{ r.label }}

--- a/templates/search.html
+++ b/templates/search.html
@@ -38,6 +38,24 @@
             });
           });
 
+        document
+          .querySelectorAll(".distance-group .toggle-button")
+          .forEach((btn) => {
+            btn.addEventListener("click", () => {
+              const wasSelected = btn.classList.contains("selected");
+              document
+                .querySelectorAll(".distance-group .toggle-button")
+                .forEach((b) => b.classList.remove("selected"));
+              const hidden = document.querySelector('input[name="distance"]');
+              if (wasSelected) {
+                if (hidden) hidden.value = "";
+              } else {
+                btn.classList.add("selected");
+                if (hidden) hidden.value = btn.dataset.value;
+              }
+            });
+          });
+
         document.querySelectorAll(".filter-input").forEach((input) => {
           input.addEventListener("input", () => {
             const box = input.closest(".tag-box");
@@ -116,6 +134,35 @@
           <select name="context"></select>
         </div>
 
+        <!-- Distance selector -->
+        <div class="form-row">
+          <div class="toggle-group distance-group">
+            <div
+              class="toggle-button {% if args.get('distance')=='Short' %}selected{% endif %}"
+              data-value="Short"
+            >
+              Short
+            </div>
+            <div
+              class="toggle-button {% if args.get('distance')=='Medium' %}selected{% endif %}"
+              data-value="Medium"
+            >
+              Medium
+            </div>
+            <div
+              class="toggle-button {% if args.get('distance')=='Deep' %}selected{% endif %}"
+              data-value="Deep"
+            >
+              Deep
+            </div>
+          </div>
+          <input
+            type="hidden"
+            name="distance"
+            value="{{ args.get('distance','') }}"
+          />
+        </div>
+
         <hr class="section-divider" />
 
         <div class="form-group">
@@ -131,7 +178,7 @@
         <div id="roles-section" class="tag-section">
           <label>Role</label>
           <div class="column-block">
-            <select class="role-select" name="offense_role"></select>
+            <select class="role-select" name="role"></select>
           </div>
           <input
             type="hidden"

--- a/templates/tagger.html
+++ b/templates/tagger.html
@@ -23,29 +23,18 @@
           document.querySelector("select[name='context']").value
         );
         localStorage.setItem(
-          "lastOffenseRole",
-          document.querySelector("select[name='offense_role']").value
-        );
-        localStorage.setItem(
-          "lastDefenseRole",
-          document.querySelector("select[name='defense_role']").value
+          "lastRole",
+          document.querySelector("select[name='role']").value
         );
       }
 
       function closeAfterSubmit() {
         const player = document.querySelector('input[name="player"]').value;
-        const side =
-          document.querySelector(".side-group .toggle-button.selected")?.dataset
-            .value || "Offense";
         const quality =
           document.querySelector(".quality-group .toggle-button.selected")
             ?.dataset.value || "";
         localStorage.setItem("lastPlayer", player);
-        localStorage.setItem("lastSide", side);
         localStorage.setItem("lastQuality", quality);
-        ("Offense");
-        localStorage.setItem("lastPlayer", player);
-        localStorage.setItem("lastSide", side);
         saveSelectValues();
         const subInput = document.querySelector('input[name="subroles"]');
         if (subInput) {
@@ -84,10 +73,8 @@
           localStorage.getItem("lastSituation") || "";
         document.querySelector("select[name='context']").value =
           localStorage.getItem("lastContext") || "";
-        document.querySelector("select[name='offense_role']").value =
-          localStorage.getItem("lastOffenseRole") || "";
-        document.querySelector("select[name='defense_role']").value =
-          localStorage.getItem("lastDefenseRole") || "";
+        document.querySelector("select[name='role']").value =
+          localStorage.getItem("lastRole") || "";
         if (typeof updateRoles === "function") updateRoles();
       }
 
@@ -97,8 +84,7 @@
           "lastOutcome",
           "lastSituation",
           "lastContext",
-          "lastOffenseRole",
-          "lastDefenseRole",
+          "lastRole",
           "lastSubroles",
         ].forEach((k) => localStorage.removeItem(k));
         setSelectValues();
@@ -106,20 +92,10 @@
 
       window.onload = function () {
         const lastPlayer = localStorage.getItem("lastPlayer");
-        const lastSide = localStorage.getItem("lastSide");
-
         const lastQuality = localStorage.getItem("lastQuality");
 
         if (lastPlayer)
           document.querySelector('input[name="player"]').value = lastPlayer;
-        if (lastSide) {
-          document
-            .querySelectorAll(".side-group .toggle-button")
-            .forEach((btn) => {
-              btn.classList.toggle("selected", btn.dataset.value === lastSide);
-            });
-          document.querySelector('input[name="side"]').value = lastSide;
-        }
         if (lastQuality) {
           document
             .querySelectorAll(".quality-group .toggle-button")
@@ -182,18 +158,6 @@
         }
       }
 
-      function toggleSide(event) {
-        document
-          .querySelectorAll(".side-group .toggle-button")
-          .forEach((btn) => btn.classList.remove("selected"));
-        event.target.classList.add("selected");
-        document.querySelector('input[name="side"]').value =
-          event.target.dataset.value;
-        if (event.target.dataset.value !== localStorage.getItem("lastSide")) {
-          clearSavedSelections();
-        }
-      }
-
       function toggleQuality(event) {
         const btn = event.currentTarget || event.target;
         const wasSelected = btn.classList.contains("selected");
@@ -235,38 +199,6 @@
             list="player-list"
           />
           <datalist id="player-list"></datalist>
-          <div class="toggle-group side-group">
-            <div
-              class="toggle-button selected"
-              data-value="Offense"
-              onclick="toggleSide(event)"
-            >
-              Offense
-            </div>
-            <div
-              class="toggle-button"
-              data-value="Defense"
-              onclick="toggleSide(event)"
-            >
-              Defense
-            </div>
-          </div>
-          <input type="hidden" name="side" value="Offense" />
-        </div>
-
-        <hr class="section-divider" />
-
-        <div class="form-row">
-          <select name="playtype"></select>
-          <select name="situation"></select>
-        </div>
-
-        <div class="form-row">
-          <select name="outcome"></select>
-          <select name="context"></select>
-        </div>
-
-        <div class="form-row">
           <div class="toggle-group quality-group">
             <div
               class="toggle-button"
@@ -288,6 +220,18 @@
 
         <hr class="section-divider" />
 
+        <div class="form-row">
+          <select name="playtype"></select>
+          <select name="situation"></select>
+        </div>
+
+        <div class="form-row">
+          <select name="outcome"></select>
+          <select name="context"></select>
+        </div>
+
+        <hr class="section-divider" />
+
         <div class="form-group">
           <label>Traits</label>
           <div class="chip-row" data-field="traits"></div>
@@ -296,14 +240,9 @@
 
         <!-- Roles -->
         <div id="roles-section" class="tag-section">
-          <label>Roles</label>
-          <div class="dual-column">
-            <div class="column-block">
-              <select class="role-select" name="offense_role"></select>
-            </div>
-            <div class="column-block">
-              <select class="role-select" name="defense_role"></select>
-            </div>
+          <label>Role</label>
+          <div class="column-block">
+            <select class="role-select" name="role"></select>
           </div>
           <input type="hidden" name="roles" />
         </div>
@@ -312,35 +251,17 @@
         <details class="subrole-drawer">
           <summary>SubRoles</summary>
           <div id="subroles-section" class="tag-section">
-            <div class="dual-column compact-mode">
-              <div class="column-block">
-                <div class="tag-box">
-                  <div class="box-header-row">
-                    <span class="box-title">Offense</span>
-                    <input
-                      type="text"
-                      class="filter-input"
-                      placeholder="Search..."
-                      oninput="filterList(this)"
-                    />
-                  </div>
-                  <div class="tag-list scrollable" data-filter-group></div>
-                </div>
+            <div class="tag-box">
+              <div class="box-header-row">
+                <span class="box-title">SubRoles</span>
+                <input
+                  type="text"
+                  class="filter-input"
+                  placeholder="Search..."
+                  oninput="filterList(this)"
+                />
               </div>
-              <div class="column-block">
-                <div class="tag-box">
-                  <div class="box-header-row">
-                    <span class="box-title">Defense</span>
-                    <input
-                      type="text"
-                      class="filter-input"
-                      placeholder="Search..."
-                      oninput="filterList(this)"
-                    />
-                  </div>
-                  <div class="tag-list scrollable" data-filter-group></div>
-                </div>
-              </div>
+              <div class="tag-list scrollable" data-filter-group></div>
             </div>
             <input type="hidden" name="subroles" />
           </div>

--- a/templates/tagger.html
+++ b/templates/tagger.html
@@ -23,13 +23,8 @@
           document.querySelector("select[name='context']").value
         );
         localStorage.setItem(
-<<<<<<< HEAD
           "lastRole",
-          document.querySelector("select[name='role']").value
-=======
-          "lastOffenseRole",
-          document.querySelector("select[name='offense_role']").value
->>>>>>> origin/main
+          document.querySelector("select[name='role']").value || ""
         );
       }
 
@@ -38,8 +33,12 @@
         const quality =
           document.querySelector(".quality-group .toggle-button.selected")
             ?.dataset.value || "";
+        const distance =
+          document.querySelector(".distance-group .toggle-button.selected")
+            ?.dataset.value || "";
         localStorage.setItem("lastPlayer", player);
         localStorage.setItem("lastQuality", quality);
+        localStorage.setItem("lastDistance", distance);
         saveSelectValues();
         const subInput = document.querySelector('input[name="subroles"]');
         if (subInput) {
@@ -78,13 +77,10 @@
           localStorage.getItem("lastSituation") || "";
         document.querySelector("select[name='context']").value =
           localStorage.getItem("lastContext") || "";
-<<<<<<< HEAD
-        document.querySelector("select[name='role']").value =
-          localStorage.getItem("lastRole") || "";
-=======
-        document.querySelector("select[name='offense_role']").value =
-          localStorage.getItem("lastOffenseRole") || "";
->>>>>>> origin/main
+        const roleSelect = document.querySelector("select[name='role']");
+        if (roleSelect) {
+          roleSelect.value = localStorage.getItem("lastRole") || "";
+        }
         if (typeof updateRoles === "function") updateRoles();
       }
 
@@ -94,11 +90,7 @@
           "lastOutcome",
           "lastSituation",
           "lastContext",
-<<<<<<< HEAD
           "lastRole",
-=======
-          "lastOffenseRole",
->>>>>>> origin/main
           "lastSubroles",
         ].forEach((k) => localStorage.removeItem(k));
         setSelectValues();
@@ -107,6 +99,7 @@
       window.onload = function () {
         const lastPlayer = localStorage.getItem("lastPlayer");
         const lastQuality = localStorage.getItem("lastQuality");
+        const lastDistance = localStorage.getItem("lastDistance");
 
         if (lastPlayer)
           document.querySelector('input[name="player"]').value = lastPlayer;
@@ -120,6 +113,17 @@
               );
             });
           document.querySelector('input[name="quality"]').value = lastQuality;
+        }
+        if (lastDistance) {
+          document
+            .querySelectorAll(".distance-group .toggle-button")
+            .forEach((btn) => {
+              btn.classList.toggle(
+                "selected",
+                btn.dataset.value === lastDistance
+              );
+            });
+          document.querySelector('input[name="distance"]').value = lastDistance;
         }
         loadPlayers();
         setSelectValues();
@@ -187,6 +191,21 @@
         }
       }
 
+      function toggleDistance(event) {
+        const btn = event.currentTarget || event.target;
+        const wasSelected = btn.classList.contains("selected");
+        document
+          .querySelectorAll(".distance-group .toggle-button")
+          .forEach((b) => b.classList.remove("selected"));
+        const hidden = document.querySelector('input[name="distance"]');
+        if (wasSelected) {
+          if (hidden) hidden.value = "";
+        } else {
+          btn.classList.add("selected");
+          if (hidden) hidden.value = btn.dataset.value;
+        }
+      }
+
       function filterList(input) {
         const box = input.closest(".tag-box");
         const container = box.querySelector(".tag-list");
@@ -244,6 +263,34 @@
           <select name="context"></select>
         </div>
 
+        <!-- Distance selector -->
+        <div class="form-row">
+          <div class="toggle-group distance-group">
+            <div
+              class="toggle-button"
+              data-value="Short"
+              onclick="toggleDistance(event)"
+            >
+              Short
+            </div>
+            <div
+              class="toggle-button"
+              data-value="Medium"
+              onclick="toggleDistance(event)"
+            >
+              Medium
+            </div>
+            <div
+              class="toggle-button"
+              data-value="Deep"
+              onclick="toggleDistance(event)"
+            >
+              Deep
+            </div>
+          </div>
+          <input type="hidden" name="distance" value="" />
+        </div>
+
         <hr class="section-divider" />
 
         <div class="form-group">
@@ -256,11 +303,7 @@
         <div id="roles-section" class="tag-section">
           <label>Role</label>
           <div class="column-block">
-<<<<<<< HEAD
             <select class="role-select" name="role"></select>
-=======
-            <select class="role-select" name="offense_role"></select>
->>>>>>> origin/main
           </div>
           <input type="hidden" name="roles" />
         </div>

--- a/tests/test_tag_utils.py
+++ b/tests/test_tag_utils.py
@@ -2,7 +2,6 @@ import os
 import json
 from pathlib import Path
 import importlib
-
 import tempfile
 
 import pytest
@@ -26,7 +25,6 @@ def test_process_clip_tags(monkeypatch, tmp_path):
 
     data = {
         "player": ["Mahomes"],
-        "side": ["Offense"],
         "playtype": ["dropback-pass"],
         "outcome": ["Completion"],
         "traits": [],
@@ -40,8 +38,8 @@ def test_process_clip_tags(monkeypatch, tmp_path):
 
     tag_utils.process_clip_tags(str(clip_path), data)
 
-    player_dir = base / "Mahomes" / "Offense"
-    files = list(player_dir.iterdir())
+    player_dir = base / "Mahomes"
+    files = [p for p in player_dir.iterdir() if p.suffix == ".mp4"]
     assert len(files) == 1
     saved = files[0]
     assert saved.name == "dropback-pass_clean-pocket_Completion.mp4"
@@ -70,7 +68,6 @@ def test_process_clip_tags_duplicates(monkeypatch, tmp_path):
 
     data = {
         "player": ["Mahomes"],
-        "side": ["Offense"],
         "playtype": ["dropback-pass"],
         "outcome": ["Completion"],
         "traits": [],
@@ -85,6 +82,10 @@ def test_process_clip_tags_duplicates(monkeypatch, tmp_path):
     tag_utils.process_clip_tags(str(clip1), data)
     tag_utils.process_clip_tags(str(clip2), data)
 
-    player_dir = base / "Mahomes" / "Offense"
-    names = sorted(p.name for p in player_dir.iterdir())
-    assert names == ["dropback-pass_clean-pocket_Completion.mp4", "dropback-pass_clean-pocket_Completion_1.mp4"]
+    player_dir = base / "Mahomes"
+    names = sorted(p.name for p in player_dir.glob("*.mp4"))
+    assert names == [
+        "dropback-pass_clean-pocket_Completion.mp4",
+        "dropback-pass_clean-pocket_Completion_1.mp4",
+    ]
+


### PR DESCRIPTION
## Summary
- Replace Offense/Defense side toggle with Good/Bad quality buttons on tagging and search pages
- Remove side handling from backend and CLI utilities
- Simplify roles and subroles to offense-only variants
- Clean up remaining offense-specific role references

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5864390c483268536fd1393915a29